### PR TITLE
hotfix: dataetime 오차범위 5초 이내로 수정

### DIFF
--- a/transactions/tests/test_transaction_model.py
+++ b/transactions/tests/test_transaction_model.py
@@ -44,6 +44,9 @@ class TransactionModelTest(TestCase):
         self.assertEqual(transaction.transaction_type, Transaction.DEPOSIT)
         self.assertEqual(transaction.transaction_method, "Online")
 
-        now = timezone.now().replace(microsecond=0)
-        transaction_datetime = transaction.transaction_datetime.replace(microsecond=0)
-        self.assertEqual(transaction_datetime, now)
+        now = timezone.now()
+        transaction_datetime = transaction.transaction_datetime
+
+        # 5초의 오차 범위를 허용
+        time_difference = abs((now - transaction_datetime).total_seconds())
+        self.assertLess(time_difference, 5, "Transaction datetime should be within 5 seconds of current time")


### PR DESCRIPTION
똑같이 맞추면 테스트중 초가 넘어버려 실패하기때문에 오차범위 5초로 수정했습니다